### PR TITLE
fix: add glob build dependency on Windows

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 cc = "1.0"
 bindgen = "0.54.0"
 
+[target.'cfg(target_env = "msvc")'.build-dependencies]
+glob = "0.3.0"
+
 [dependencies]
 #paired = "0.19.1"
 paired = "0.20.0"


### PR DESCRIPTION
I haven't properly tested it as I'm not on Windows, but it should be
better than before.