### PR TITLE
fix the compilation error on aarch64 platform

### DIFF
--- a/src/fil_blst.cpp
+++ b/src/fil_blst.cpp
@@ -10,7 +10,10 @@
 #include <thread>
 #include <atomic>
 #include <map>
+
+#if (defined(__x86_64__) || defined(__x86_64))
 #include <xmmintrin.h>
+#endif
 
 #include "thread_pool.hpp"
 #include "fil_blst.h"


### PR DESCRIPTION
This fixes the compilation error on the aarch64 platform: 
```
[root@node1 fil-blst]# ./build.sh
+ cc -O -fPIC -Wall -Wextra -Werror -c ./src/server.c
+ cc -O -fPIC -Wall -Wextra -Werror -c ./build/assembly.S
+ ar rc libblst.a assembly.o server.o
src/fil_blst.cpp:13:10: fatal error: xmmintrin.h: No such file or directory
   13 | #include <xmmintrin.h>
      |          ^~~~~~~~~~~~~
compilation terminated.
```
This header file contains the sse2 intrinsics function, which is not supported by the aarch64 platform.
